### PR TITLE
Use consistent naming conventions and build tools.

### DIFF
--- a/.csslintrc
+++ b/.csslintrc
@@ -1,1 +1,0 @@
---ignore=important,box-sizing

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,0 @@
-install:
-	npm install
-	./node_modules/component/bin/component install --dev
-
-test:
-	npm test
-	./node_modules/component/bin/component build --dev
-
-.PHONY: install

--- a/README.md
+++ b/README.md
@@ -14,10 +14,9 @@ Read more about [SUIT](https://github.com/suitcss/suit/).
 
 ## Installation
 
-* [Bower](http://bower.io/): `bower install --save suit-grid`
-* [Component(1)](http://component.io/): `component install suitcss/grid`
-* Download: [zip](https://github.com/suitcss/grid/zipball/master)
-* Git: `git clone https://github.com/suitcss/grid`
+* [Component(1)](https://github.com/component/component/): `component install suitcss/components-button`
+* [npm](http://npmjs.org/): `npm install --save suit-components-button`
+* [Bower](http://bower.io/): `bower install --save suit-button`
 
 ## Features
 

--- a/bower.json
+++ b/bower.json
@@ -3,20 +3,16 @@
   "version": "1.1.0",
   "author": "Nicolas Gallagher",
   "main": "grid.css",
-  "devDependencies": {
-    "suit-utils-dimension": "~0.5.0",
-    "suit-utils-offset": "~0.3.0",
-    "suit-test": "~0.1.0"
-  },
   "ignore": [
-    "build",
-    "components",
-    "test",
     ".*",
-    "Makefile",
     "CHANGELOG.md",
     "component.json",
     "package.json",
     "test.html"
-  ]
+  ],
+  "devDependencies": {
+    "suit-utils-dimension": "~0.5.0",
+    "suit-utils-offset": "~0.3.0",
+    "suit-test": "~0.1.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,28 @@
 {
-  "name": "suit-grid",
-  "private": true,
+  "name": "suit-components-grid",
+  "description": "",
   "version": "1.1.0",
+  "style": "grid.css",
+  "files": [
+    "grid.css",
+    "component.json"
+  ],
   "devDependencies": {
-    "component": "*",
-    "csslint": ">=0.9.10"
+    "component": "0.19.x",
+    "component-builder-suit": "0.2.x",
+    "suitcss-preprocessor": "0.1.x"
   },
   "scripts": {
-    "test": "./node_modules/.bin/csslint *.css"
-  }
+    "build": "npm run component && npm run preprocess",
+    "build-test": "npm run component-dev && npm run preprocess",
+    "component": "component install && component build --use component-builder-suit",
+    "component-dev": "component install --dev && component build --dev --use component-builder-suit",
+    "preprocess": "suitcss build/build.css build/build.css"
+  },
+  "keywords": [
+    "suit",
+    "css",
+    "component",
+    "grid"
+  ]
 }


### PR DESCRIPTION
Use consistent naming conventions and build tools. Should probably update the other outdated components too.
