### PR TITLE
Reset letter spacing

### DIFF
--- a/lib/grid.css
+++ b/lib/grid.css
@@ -31,6 +31,7 @@
   margin: 0; /* 1 */
   padding: 0; /* 1 */
   text-align: left; /* 3 */
+  letter-spacing: 0;
 }
 
 /**


### PR DESCRIPTION
I was having an issue in Firefox where letter spacing was throwing off my entire grid. 

I did have letter spacing on for the entire page. I could have removed it and added it to individual elements, but felt like it may make sense here. 