### PR TITLE
Switch to flexbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Read more about [SUIT CSS](https://github.com/suitcss/suit/).
 
 ## Configurable variables
 
-* `--Grid-font-size`: the font-size to use within the Grid (defaults to 1rem).
 * `--Grid-gutter-size`: the width of the gutter applied by the `Grid--withGutter` modifier class.
 
 ## Use

--- a/README.md
+++ b/README.md
@@ -47,7 +47,19 @@ Read more about [SUIT CSS](https://github.com/suitcss/suit/).
 ## Use
 
 A simple grid is easy to create. A grid container can have any number of child
-cells.
+cells. When used with `Grid--fit` space is evenly distributed without need for
+sizing utilities.
+
+```html
+<div class="Grid Grid--fit Grid--withGutter">
+  <div class="Grid-cell"></div>
+  <div class="Grid-cell"></div>
+  <div class="Grid-cell"></div>
+  <div class="Grid-cell"></div>
+</div>
+```
+
+For more granular control over layout make use of modifiers and sizing utilities.
 
 ```html
 <div class="Grid [Grid--alignCenter|Grid--alignRight|Grid--alignMiddle|Grid--alignBottom|Grid--fit|Grid--equalHeight]">

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://secure.travis-ci.org/suitcss/components-grid.png?branch=master)](http://travis-ci.org/suitcss/components-grid)
 
-A CSS grid component. The grid makes use of `inline-block` and `box-sizing` to
+A CSS grid component. The grid makes use of `flexbox` and `box-sizing` to
 provide features that float-based layouts cannot.
 
 N.B. This component relies on particular dimensions being applied to cells in
@@ -20,11 +20,12 @@ Read more about [SUIT CSS](https://github.com/suitcss/suit/).
 
 * Fluid layout.
 * Intelligent cell wrapping.
+* Evenly fit cell spacing
+* Equal height columns
 * Horizontal centering of cells.
 * Custom vertical alignment of cells (top, bottom, or middle).
 * Cell width is controlled independently of grid gutter.
 * Infinite nesting.
-* Built-in redundancy.
 
 ## Available classes
 
@@ -33,6 +34,8 @@ Read more about [SUIT CSS](https://github.com/suitcss/suit/).
 * `Grid--alignRight`: right-align all child `Grid-cell`
 * `Grid--alignMiddle`: middle-align all child `Grid-cell`
 * `Grid--alignBottom`: bottom-align all child `Grid-cell`
+* `Grid--fit`: evenly distribute space amongst all child `Grid-cell`
+* `Grid--equalHeight`: all child `Grid-cell` match height of the tallest
 * `Grid--withGutter`: adds a gutter between cells
 * `Grid-cell`: a child cell of `Grid` that wraps grid content
 * `Grid-cell--center`: center an individual `Grid-cell`
@@ -48,7 +51,7 @@ A simple grid is easy to create. A grid container can have any number of child
 cells.
 
 ```html
-<div class="Grid [Grid--alignCenter|Grid--alignRight|Grid--alignMiddle|Grid--alignBottom]">
+<div class="Grid [Grid--alignCenter|Grid--alignRight|Grid--alignMiddle|Grid--alignBottom|Grid--fit|Grid--equalHeight]">
   <div class="Grid-cell u-size1of2 u-lg-size6of12"></div>
   <div class="Grid-cell u-size1of2 u-lg-size4of12"></div>
   <div class="Grid-cell u-size1of3 u-lg-size2of12"></div>
@@ -87,7 +90,7 @@ BAD:
 ```
 
 You can nest grids in any context, including one that uses dimension or offset
-utilities, but keep in mind that the the dimensions will be relative to the
+utilities, but keep in mind that the dimensions will be relative to the
 grid's width, and not the width of the whole application.
 
 ```html
@@ -114,10 +117,16 @@ To generate a build:
 npm run build
 ```
 
-To generate the testing build.
+To generate the testing build:
 
 ```
 npm run build-test
+```
+
+To watch the files for making changes to test:
+
+```
+npm run watch
 ```
 
 Basic visual tests are in `test/index.html`.
@@ -126,6 +135,8 @@ Basic visual tests are in `test/index.html`.
 
 * Google Chrome (latest)
 * Opera (latest)
-* Firefox 4+
-* Safari 5+
-* Internet Explorer 9+
+* Firefox 28+
+* Safari 6.1+
+* Internet Explorer 10+
+
+Refer to the [caniuse](http://caniuse.com/) page for [flexbox](http://caniuse.com/#feat=flexbox)

--- a/build.js
+++ b/build.js
@@ -1,0 +1,18 @@
+const postcss = require('postcss');
+const bemLinter = require('postcss-bem-linter');
+const reporter = require('postcss-reporter');
+
+module.exports = {
+  use: [
+    "postcss-import",
+    "postcss-custom-properties",
+    "postcss-calc",
+    "postcss-custom-media",
+    "autoprefixer"
+  ],
+  "postcss-import": {
+    transform(css) {
+      return postcss([bemLinter, reporter]).process(css).css;
+    }
+  }
+};

--- a/build.js
+++ b/build.js
@@ -8,11 +8,15 @@ module.exports = {
     "postcss-custom-properties",
     "postcss-calc",
     "postcss-custom-media",
-    "autoprefixer"
+    "autoprefixer",
+    "postcss-reporter"
   ],
   "postcss-import": {
     transform(css) {
       return postcss([bemLinter, reporter]).process(css).css;
+    },
+    "postcss-reporter": {
+      clearMessages: true
     }
   }
 };

--- a/lib/grid.css
+++ b/lib/grid.css
@@ -64,8 +64,8 @@
 /**
  * Modifier: allow cells to equal distribute width
  *
- * 1. Be explicit to work around IE10 bug with shorthand flex
- *    https://github.com/philipwalton/flexbugs#6-the-default-flex-value-has-changed
+ * 1. Provide all values to avoid IE10 bug with shorthand flex - http://git.io/vllC7
+ *    Use `0%` to avoid bug in IE10/11 with unitless flex basis - http://git.io/vllWx
  */
 
 .Grid--fit > .Grid-cell {

--- a/lib/grid.css
+++ b/lib/grid.css
@@ -1,4 +1,4 @@
-/** @define Grid; use strict */
+/** @define Grid */
 
 :root {
   --Grid-font-size: 1rem;
@@ -20,17 +20,14 @@
  *
  * 1. Account for browser defaults of elements that might be the root node of
  *    the component.
- * 2. Remove inter-cell whitespace that appears between `inline-block` child
- *    elements.
- * 3. Ensure consistent default alignment.
  */
 
 .Grid {
-  display: block; /* 1 */
-  font-size: 0; /* 2 */
+  display: flex; /* 1 */
+  box-sizing: border-box;
+  flex-flow: row wrap;
   margin: 0; /* 1 */
   padding: 0; /* 1 */
-  text-align: left; /* 3 */
 }
 
 /**
@@ -38,7 +35,7 @@
  */
 
 .Grid--alignCenter {
-  text-align: center;
+  justify-content: center;
 }
 
 /**
@@ -46,31 +43,43 @@
  */
 
 .Grid--alignRight {
-  text-align: right;
+  justify-content: flex-end;
 }
 
 /**
  * Modifier: middle-align grid cells
  */
 
-.Grid--alignMiddle > .Grid-cell {
-  vertical-align: middle;
+.Grid--alignMiddle {
+  align-items: center;
 }
 
 /**
  * Modifier: bottom-align grid cells
  */
 
-.Grid--alignBottom > .Grid-cell {
-  vertical-align: bottom;
+.Grid--alignBottom {
+  align-items: flex-end;
+}
+
+/**
+ * Modifier: allow cells to equal distribute width
+ */
+
+.Grid--fit > .Grid-cell {
+  flex: 1;
+}
+
+/**
+ * Modifier: all cells match height of tallest cell in a row
+ */
+
+.Grid--equalHeight > .Grid-cell {
+  display: flex;
 }
 
 /**
  * Modifier: gutters
- *
- * NOTE: this can trigger a horizontal scrollbar if the component is as wide as
- * the viewport. Use padding on a container, or `overflow-x:hidden` to protect
- * against it.
  */
 
 .Grid--withGutter {
@@ -86,24 +95,14 @@
 
 /**
  * No explicit width by default. Rely on combining `Grid-cell` with a dimension
- * utility or a component class that extends 'grid'.
+ * utility or a component class that extends 'Grid'.
  *
- * 1. Fundamentals of the non-float grid layout.
- * 2. Reset font size change made in `Grid`.
- * 3. Keeps content correctly aligned with the grid direction.
- * 4. Controls vertical positioning of units.
- * 5. Make cells full-width by default.
+ * 1. Set flex items to full width by default
  */
 
 .Grid-cell {
-  box-sizing: border-box;
-  display: inline-block; /* 1 */
-  font-size: var(--Grid-font-size); /* 2 */
-  margin: 0;
-  padding: 0;
-  text-align: left; /* 3 */
-  vertical-align: top; /* 4 */
-  width: 100%; /* 5 */
+  flex: 0 0 100%; /* 1 */
+  box-sizing: inherit;
 }
 
 /**
@@ -113,6 +112,5 @@
  */
 
 .Grid-cell--center {
-  display: block;
   margin: 0 auto;
 }

--- a/lib/grid.css
+++ b/lib/grid.css
@@ -63,10 +63,13 @@
 
 /**
  * Modifier: allow cells to equal distribute width
+ *
+ * 1. Be explicit to work around IE10 bug with shorthand flex
+ *    https://github.com/philipwalton/flexbugs#6-the-default-flex-value-has-changed
  */
 
 .Grid--fit > .Grid-cell {
-  flex: 1;
+  flex: 1 1 0%; /* 1 */
 }
 
 /**

--- a/lib/grid.css
+++ b/lib/grid.css
@@ -1,7 +1,6 @@
 /** @define Grid */
 
 :root {
-  --Grid-font-size: 1rem;
   --Grid-gutter-size: 20px;
 }
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "postcss-reporter": "^1.3.0",
     "suitcss-components-test": "*",
     "suitcss-utils-offset": "~0.5.0",
-    "suitcss-utils-size": "~0.7.0"
+    "suitcss-utils-size": "~0.8.0"
   },
   "scripts": {
     "build": "npm run setup && npm run preprocess",

--- a/package.json
+++ b/package.json
@@ -8,17 +8,26 @@
     "lib"
   ],
   "devDependencies": {
+    "autoprefixer": "^6.0.3",
+    "postcss": "^5.0.10",
+    "postcss-bem-linter": "^2.0.0",
+    "postcss-calc": "^5.0.0",
+    "postcss-cli": "^2.3.2",
+    "postcss-custom-media": "^5.0.0",
+    "postcss-custom-properties": "^5.0.0",
+    "postcss-import": "^7.1.0",
+    "postcss-reporter": "^1.3.0",
     "suitcss-components-test": "*",
-    "suitcss-preprocessor": "~0.4.0",
     "suitcss-utils-offset": "~0.5.0",
     "suitcss-utils-size": "~0.7.0"
   },
   "scripts": {
     "build": "npm run setup && npm run preprocess",
     "build-test": "npm run setup && npm run preprocess-test",
-    "preprocess": "suitcss index.css build/build.css",
-    "preprocess-test": "suitcss test/test.css build/test.css",
-    "setup": "npm install && mkdir -p build"
+    "preprocess": "postcss -c build.js -o build/build.css index.css",
+    "preprocess-test": "postcss -c build.js -o build/test.css test/test.css",
+    "setup": "npm install && mkdir -p build",
+    "watch": "npm run preprocess-test -- -w"
   },
   "repository": {
     "type": "git",

--- a/test/index.html
+++ b/test/index.html
@@ -367,4 +367,26 @@
       </div>
     </div>
   </div>
+  <h3 class="Test-it">correctly adds gutters with Grid--fit</h3>
+  <div class="Test-run">
+    <div class="Grid Grid--withGutter Grid--fit">
+      <div class="Grid-cell">
+        <div class="fixture-Box">1</div>
+      </div>
+      <div class="Grid-cell">
+        <div class="fixture-Box">2</div>
+      </div>
+      <div class="Grid-cell">
+        <div class="fixture-Box">3</div>
+      </div>
+    </div>
+    <div class="Grid Grid--withGutter Grid--fit">
+      <div class="Grid-cell">
+        <div class="fixture-Box">1</div>
+      </div>
+      <div class="Grid-cell">
+        <div class="fixture-Box">2</div>
+      </div>
+    </div>
+  </div>
 </div>

--- a/test/index.html
+++ b/test/index.html
@@ -132,6 +132,29 @@
     </div>
   </div>
 
+  <h3 class="Test-it">supports u-sizeFill on cells with no width</h3>
+  <div class="Test-run">
+    <div class="Grid">
+      <div class="Grid-cell u-size1of4">
+        <div class="fixture-Box">1/4</div>
+      </div>
+      <div class="Grid-cell u-sizeFill">
+        <div class="fixture-Box">auto</div>
+      </div>
+    </div>
+    <div class="Grid">
+      <div class="Grid-cell u-size2of12">
+        <div class="fixture-Box">2/12</div>
+      </div>
+      <div class="Grid-cell u-sizeFill">
+        <div class="fixture-Box">auto</div>
+      </div>
+      <div class="Grid-cell u-size2of12">
+        <div class="fixture-Box">2/12</div>
+      </div>
+    </div>
+  </div>
+
   <h2 class="Test-describe">.Grid--alignCenter</h2>
   <h3 class="Test-it">center-aligns all grid cells but not their content</h3>
   <div class="Test-run">

--- a/test/index.html
+++ b/test/index.html
@@ -10,6 +10,7 @@
     border: 1px solid black;
     margin-bottom: 10px;
     min-height: 50px;
+    width: 100%;
   }
 
   .fixture-Box--doubleHeight {
@@ -197,6 +198,58 @@
       </div>
       <div class="Grid-cell u-size1of4">
         <div class="fixture-Box">4</div>
+      </div>
+    </div>
+  </div>
+
+  <h2 class="Test-describe">.Grid--fit</h2>
+  <h3 class="Test-it">evenly distribute space between cells without sizing classes</h3>
+  <div class="Test-run">
+    <div class="Grid Grid--fit">
+      <div class="Grid-cell">
+        <div class="fixture-Box">1</div>
+      </div>
+      <div class="Grid-cell">
+        <div class="fixture-Box">2</div>
+      </div>
+      <div class="Grid-cell">
+        <div class="fixture-Box">3</div>
+      </div>
+    </div>
+    <div class="Grid Grid--fit">
+      <div class="Grid-cell">
+        <div class="fixture-Box">1</div>
+      </div>
+      <div class="Grid-cell">
+        <div class="fixture-Box">2</div>
+      </div>
+      <div class="Grid-cell">
+        <div class="fixture-Box">3</div>
+      </div>
+      <div class="Grid-cell">
+        <div class="fixture-Box">4</div>
+      </div>
+      <div class="Grid-cell">
+        <div class="fixture-Box">5</div>
+      </div>
+      <div class="Grid-cell">
+        <div class="fixture-Box">6</div>
+      </div>
+    </div>
+  </div>
+
+  <h2 class="Test-describe">.Grid--equalHeight</h2>
+  <h3 class="Test-it">equal height columns based on tallest Grid-cell</h3>
+  <div class="Test-run">
+    <div class="Grid Grid--equalHeight">
+      <div class="Grid-cell u-size1of3">
+        <div class="fixture-Box">1</div>
+      </div>
+      <div class="Grid-cell u-size1of3">
+        <div class="fixture-Box">2<br> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum mollis velit non gravida venenatis. Praesent consequat lectus purus, ut scelerisque velit condimentum eu. Maecenas sagittis ante ut turpis varius interdum. Quisque tellus ipsum, eleifend non ipsum id, suscipit ultricies neque.</div>
+      </div>
+      <div class="Grid-cell u-size1of3">
+        <div class="fixture-Box">3</div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This refactors the grid to use flexbox. The goal here was to keep the API the same so that it could be dropped into an existing site with the SUIT grid and everything work. This includes working with the other utilities where possible.

Here are the tests with the flexbox version - https://dl.dropboxusercontent.com/u/1709558/suitcss-grid/index.html I've also added a couple new bits like `fix` and `equalHeight`. I was able to get the existing tests to match without making any changes to the markup, which was a plus. 

This does depend on some changes that I've [made to utils-size](https://github.com/simonsmith/utils-size) as well. Namely losing the various `sizeFit` and `sizeFill` utils and adding `flex-basis` alongside `width`. The offset utils seem to work with no changes required.

A further enhancement to this will be to create a utils-flexbox (https://github.com/suitcss/suit/issues/113) which would allow even more control over the grid with things like `order` and `align-content` etc.

I'd suggest that makes grid `3.0.0` and once users are ready to support flexbox they should be able to update their package and expect everything to work as normal.

**Depends on** https://github.com/suitcss/utils-size/pull/29 

Fix #33 
Fix #35 
Fix #34 
Fix #15

@timkelty @giuseppeg 