### PR TITLE
Fix issue with u-before

### DIFF
--- a/lib/grid.css
+++ b/lib/grid.css
@@ -107,7 +107,7 @@
 
 .Grid-cell {
   box-sizing: inherit;
-  flex: 0 0 100%; /* 1 */
+  flex-basis: 100%; /* 1 */
 }
 
 /**

--- a/test/index.html
+++ b/test/index.html
@@ -25,7 +25,7 @@
   <h1 class="Test-title">SUIT CSS: <a href="https://github.com/suitcss/components-grid">Grid</a> component tests</h1>
 
   <h2 class="Test-describe">.Grid</h2>
-  <h3 class="Test-it">renders cells at fill-width by default</h3>
+  <h3 class="Test-it">renders cells at full-width by default</h3>
   <div class="Test-run">
     <div class="Grid">
       <div class="Grid-cell">


### PR DESCRIPTION
Found an issue when using `u-before` and no explicit size. It pushes the `Grid-cell` right out of the container. Setting just the `flex-basis` fixes it, and looks good in multiple browsers

``` html
   <div class="Container">
      <div class="Grid Grid--withGutter">
        <div class="Grid-cell u-before1of2">
          <div class="Item">Grid cell</div>
        </div>
      </div>
    </div>
```

Demo here: http://codepen.io/simonsmith/pen/PNxZvo