### PR TITLE
Add a fix for elements overflowing the grid

### DIFF
--- a/lib/grid.css
+++ b/lib/grid.css
@@ -103,11 +103,14 @@
  * utility or a component class that extends 'Grid'.
  *
  * 1. Set flex items to full width by default
+ * 2. Fix issue where elements with overflow extend past the
+ *    `Grid-cell` container - https://git.io/vw5oF
  */
 
 .Grid-cell {
   box-sizing: inherit;
   flex-basis: 100%; /* 1 */
+  min-width: 0; /* 2 */
 }
 
 /**

--- a/test/index.html
+++ b/test/index.html
@@ -16,6 +16,12 @@
     min-height: 100px;
   }
 
+  pre {
+    overflow: auto;
+    white-space: pre;
+    word-wrap: normal;
+  }
+
   .Test {
     padding: 0 10px;
   }
@@ -50,6 +56,18 @@
       </div>
       <div class="Grid-cell u-size1of4">
         <div class="fixture-Box">4</div>
+      </div>
+    </div>
+  </div>
+  <h3 class="Test-it">handles overflowing elements</h3>
+  <div class="Test-run">
+    <div class="Grid">
+      <div class="Grid-cell">
+        <div class="fixture-Box">
+           <pre>
+              This is some really long content that should be scrolled when the container is too small.
+           </pre>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Flex items have a min-width set to `auto` as per the spec:
https://www.w3.org/TR/css-flexbox/#min-size-auto

This causes elements like `pre` to extend past the `Grid-cell` even when
overflow is set.

Setting `min-width` to `0` fixes this and gives a more expected
behaviour in that situation.

Bug example: http://codepen.io/simonsmith/pen/BKGKBo
More detail: http://weblog.west-wind.com/posts/2016/Feb/15/Flexbox-Containers-PRE-tags-and-managing-Overflow

Have tested in several browsers and seems to work as expected